### PR TITLE
feat: refine cmake and fix macOS build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,22 +1,22 @@
 cmake_minimum_required(VERSION 3.10)
+
 project(lvgl)
-set(CMAKE_C_STANDARD 11)#C11
-set(CMAKE_CXX_STANDARD 17)#C17
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-INCLUDE_DIRECTORIES(${PROJECT_SOURCE_DIR})
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_CXX_STANDARD 11)
 
-file(GLOB_RECURSE INCLUDES "./*.h" )
+find_package(SDL2 REQUIRED SDL2)
+include_directories(
+        ${SDL2_INCLUDE_DIRS}
+        ${SDL2_INCLUDE_DIRS}/../
+        ${PROJECT_SOURCE_DIR}
+)
 
 add_subdirectory(lvgl)
 add_subdirectory(lv_drivers)
 
 SET(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin)
-SET(CMAKE_CXX_FLAGS "-O3")
 
-find_package(SDL2 REQUIRED SDL2)
-include_directories(${SDL2_INCLUDE_DIRS})
 add_executable(main main.c mouse_cursor_icon.c ${SOURCES} ${INCLUDES})
-add_compile_definitions(LV_CONF_INCLUDE_SIMPLE)
 target_link_libraries(main PRIVATE lvgl lvgl::examples lvgl::demos lvgl::drivers ${SDL2_LIBRARIES})
-add_custom_target (run COMMAND ${EXECUTABLE_OUTPUT_PATH}/main)
+add_custom_target(run COMMAND ${EXECUTABLE_OUTPUT_PATH}/main)


### PR DESCRIPTION
1. no need c++17 and CMAKE_CXX_STANDARD_REQUIRED
2. no need -03(for debug), user can -DCMAKE_BUILD_TYPE=Release instead
3. remove INCLUDES
4. **macOS SDL path should use ${SDL2_INCLUDE_DIRS}/../**