### PR TITLE
Update docker and switch to cmake

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,6 @@ ENV DISPLAY=:0
 
 COPY . .
 
-RUN make -j3
+RUN mkdir -p build && cd build && cmake .. && cmake --build . --parallel
 
-CMD ["./demo"]
+CMD ["./build/bin/main"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,9 @@
 # To do GUI forwarding on linux, the following may work (easiest method, but unsafe)
 #     xhost + && docker run --network=host --env DISPLAY=$DISPLAY lvgl
 
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
-RUN apt update && apt install -y \
+RUN apt-get update -y && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     build-essential \
     cmake \
     gcc \


### PR DESCRIPTION
With the current Makefile the project wasn't able to build with following linker errors

        main.c:(.text.startup+0xc): undefined reference to `sdl_init'
        main.c:(.text.startup+0x58): undefined reference to `sdl_display_flush'
        main.c:(.text.startup+0xbd): undefined reference to `sdl_mouse_read'
        main.c:(.text.startup+0xf0): undefined reference to `sdl_keyboard_read'
        main.c:(.text.startup+0x12b): undefined reference to `sdl_mousewheel_read'

I choose to not fix the makefile to correctly link sdl, but instead switch to cmake, as it is already installed  / listed in the Dockerfile. Which also led me to update the Ubuntu version (with `18.04` cmake was throwing errors) and updating the apt calls to be more robust for non-interactive use.
