### PR TITLE
cmake: should set include path before add lvgl subdirectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,13 +8,13 @@ INCLUDE_DIRECTORIES(${PROJECT_SOURCE_DIR})
 
 file(GLOB_RECURSE INCLUDES "./*.h" )
 
-add_subdirectory(lvgl)
-
 SET(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/bin)
 SET(CMAKE_CXX_FLAGS "-O3")
 
 find_package(SDL2 REQUIRED SDL2)
 include_directories(${SDL2_INCLUDE_DIRS})
+
+add_subdirectory(lvgl)
 add_executable(main main.c mouse_cursor_icon.c ${SOURCES} ${INCLUDES})
 add_compile_definitions(LV_CONF_INCLUDE_SIMPLE)
 target_link_libraries(main PRIVATE lvgl lvgl::examples lvgl::demos ${SDL2_LIBRARIES})


### PR DESCRIPTION
Build on mac found that the SDL2 path is not passed on to lvgl. 

With this PR, it works now.