### PR TITLE
docs: specify release version branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,21 @@ The PC simulator is cross platform.  **Windows, Linux and OSX** are supported, h
 Clone the PC project and the related sub modules:
 
 ```
-git clone --recursive https://github.com/littlevgl/pc_simulator_sdl_eclipse.git
+git clone https://github.com/littlevgl/pc_simulator_sdl_eclipse.git
+```
+
+### Checkout your LVGL version
+
+By default the repository will be on `master`.
+
+Checkout the branch that corresponds to the version of LVGL you will be using.  For example, if your project uses LVGL v8.0 then you need to checkout the corresponding release branch of this repository:
+```
+git checkout release/v8.0
+```
+
+After specifying your version, update your local the submodule dependencies specific to your version:
+```
+git submodule update --init --recursive
 ```
 
 ### Install SDL


### PR DESCRIPTION
This adds a note to the master branch explaining that different versions of LVGL have corresponding simulator examples.  This approach has several deficiencies.

- the README.md now diverges (master is different than the branches)
  - somewhat justifiable in the sense that if you got to a release branch you probably already knew you should be there
- perhaps the REAMDE.md of each branch should clearly state what dependencies they are using; e.g., the master branch would state "LVGL Simulator for latest LVGL master"?
- perhaps this sort of clarification should exist here, https://docs.lvgl.io/latest/en/html/get-started/pc-simulator.html, instead?