### PR TITLE
cmake: add LV_USE_LIBPNG support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.10)
 project(lvgl)
 
 option(LV_USE_DRAW_SDL "Use SDL draw unit" OFF)
+option(LV_USE_LIBPNG "Use libpng to decode PNG" OFF)
 
 set(CMAKE_C_STANDARD 11)#C11
 set(CMAKE_CXX_STANDARD 17)#C17
@@ -12,6 +13,7 @@ set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/bin)
 find_package(SDL2 REQUIRED SDL2)
 
 add_compile_definitions($<$<BOOL:${LV_USE_DRAW_SDL}>:LV_USE_DRAW_SDL=1>)
+add_compile_definitions($<$<BOOL:${LV_USE_LIBPNG}>:LV_USE_LIBPNG=1>)
 
 add_subdirectory(lvgl)
 target_include_directories(lvgl PUBLIC ${PROJECT_SOURCE_DIR} ${SDL2_INCLUDE_DIRS})
@@ -31,6 +33,12 @@ if(LV_USE_DRAW_SDL)
     target_include_directories(lvgl PUBLIC ${SDL2_IMAGE_INCLUDE_DIRS})
     target_link_libraries(main ${SDL2_IMAGE_LIBRARIES})
 endif(LV_USE_DRAW_SDL)
+
+if(LV_USE_LIBPNG)
+    find_package(PNG REQUIRED)
+    target_include_directories(lvgl PUBLIC ${PNG_INCLUDE_DIR})
+    target_link_libraries(main ${PNG_LIBRARY})
+endif(LV_USE_LIBPNG)
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     target_compile_options(lvgl PRIVATE

--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ The following steps can be used with CMake on a Unix-like system. This may also 
 1. Ensure CMake is installed, i.e. the `cmake` command works on the terminal.
 2. Make a new directory. The name doesn't matter but `build` will be used for this tutorial.
 3. Type `cd build`.
-4. Type `cmake ..`. CMake will generate the appropriate build files. To build with SDL draw unit, use `cmake .. -DLV_USE_DRAW_SDL=ON`
+4. Type `cmake ..`. CMake will generate the appropriate build files.
+   - To build with SDL draw unit, add `-DLV_USE_DRAW_SDL=ON` to command line
+   - To build with libpng to support PNG image, add `-DLV_USE_LIBPNG=ON` to command line
 5. Type `make -j4` or (more portable) `cmake --build . --parallel`.
 
 **NOTE:** `--parallel` is supported from CMake v3.12 onwards. If you are using an older version of CMake, remove `--parallel` from the command or use the make option.

--- a/lv_conf.h
+++ b/lv_conf.h
@@ -611,7 +611,9 @@
 #define LV_USE_LODEPNG 1
 
 /*PNG decoder(libpng) library*/
+#ifndef LV_USE_LIBPNG
 #define LV_USE_LIBPNG 0
+#endif
 
 /*BMP decoder library*/
 #define LV_USE_BMP 1


### PR DESCRIPTION
`libpng` is required to use `lv_libpng.c`.