### PR TITLE
support xcode intruments signs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,10 @@ option(LV_USE_LIBPNG "Use libpng to decode PNG" OFF)
 option(LV_USE_LIBJPEG_TURBO "Use libjpeg turbo to decode JPEG" OFF)
 option(LV_USE_FFMPEG "Use libffmpeg to display video using lv_ffmpeg" OFF)
 
+# When this option is enabled, the executable program will be signed with get-task-allow ability and can be debugged
+# with Xcode Instruments
+option(XCODE_INSTRUMENTS_SIGN "Use codesign tool to sign the executable program with get-task-allow ability" OFF)
+
 set(CMAKE_C_STANDARD 99)#C99 # lvgl officially support C99 and above
 set(CMAKE_CXX_STANDARD 17)#C17
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -87,3 +91,11 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     target_compile_options(main PRIVATE -fsanitize=address,leak,undefined)
     target_link_options(main PRIVATE -fsanitize=address,leak,undefined)
 endif()
+
+if (XCODE_INSTRUMENTS_SIGN)
+# execute post codesign
+add_custom_command(TARGET main POST_BUILD
+        COMMAND codesign -s - -v -f --entitlements=${PROJECT_SOURCE_DIR}/xcode_instruments_entitle.xml ${EXECUTABLE_OUTPUT_PATH}/main
+        COMMENT "codesign Simulator"
+)
+endif ()

--- a/mouse_cursor_icon.c
+++ b/mouse_cursor_icon.c
@@ -47,7 +47,6 @@ const LV_ATTRIBUTE_MEM_ALIGN LV_ATTRIBUTE_LARGE_CONST LV_ATTRIBUTE_IMAGE_MOUSE_C
 
 const lv_img_dsc_t mouse_cursor_icon = {
   .header.cf = LV_COLOR_FORMAT_ARGB8888,
-  .header.always_zero = 0,
   .header.w = 13,
   .header.h = 21,
   .data_size = 273 * 4,

--- a/xcode_instruments_entitle.xml
+++ b/xcode_instruments_entitle.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd"\>
+<plist version="1.0">
+<dict>
+<key>com.apple.security.get-task-allow</key>
+<true/>
+</dict>
+</plist>


### PR DESCRIPTION
When this option is open, after signed the executable file, we can use the powerful profile tools provided by Xcode named Instruments.

Here are some snapshots
<img width="1976" alt="image" src="https://github.com/lvgl/lv_port_pc_eclipse/assets/24841247/fb32590f-36d7-470d-929b-b94c8408351e">
<img width="1976" alt="image" src="https://github.com/lvgl/lv_port_pc_eclipse/assets/24841247/caba6711-2104-457b-b7ce-9f098035faf9">
