### PR TITLE
build: do not use unsupported sanitization on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,8 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
         -Wstrict-aliasing
     )
 
-    target_compile_options(main PRIVATE -fsanitize=address,leak,undefined)
-    target_link_options(main PRIVATE -fsanitize=address,leak,undefined)
+    if (UNIX)
+        target_compile_options(main PRIVATE -fsanitize=address,leak,undefined)
+        target_link_options(main PRIVATE -fsanitize=address,leak,undefined)
+    endif ()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,8 +91,8 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
         -Wstrict-aliasing
     )
 
-    if (UNIX)
+    if(NOT WIN32)
         target_compile_options(main PRIVATE -fsanitize=address,leak,undefined)
         target_link_options(main PRIVATE -fsanitize=address,leak,undefined)
-    endif ()
+    endif()
 endif()


### PR DESCRIPTION
Seems like sanitization is not supported on windows. Guard it.