### PR TITLE
docs: fix broken PC simulator README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The [LVGL](https://github.com/lvgl/lvgl) is written mainly for microcontrollers and embedded systems however you can run the library **on your PC** as well without any embedded hardware. The code written on PC can be simply copied when your are using an embedded system.
 
-The PC simulator is cross platform.  **Windows, Linux and OSX** are supported, however on Windows it's easier to get started with a [another simulator](https://docs.lvgl.io/latest/en/html/get-started/pc-simulator.html) project.
+The PC simulator is cross platform.  **Windows, Linux and OSX** are supported, however on Windows it's easier to get started with a [another simulator](https://docs.lvgl.io/master/integration/pc/index.html) project.
 
 This project uses [Eclipse CDT](https://projects.eclipse.org/projects/tools.cdt) (as an IDE) and [SDL](https://www.libsdl.org/) =a low level driver library to open a window, and handle mouse, keyboard etc.)
 


### PR DESCRIPTION
Fixes #167.

The README currently links to the old `latest/en/html/get-started/pc-simulator.html` docs URL, which is reported as a 404. This updates the link to the current LVGL PC simulator integration docs page.

Validation:
- cloned current `master` at `0c248bf`
- confirmed README contains the old `pc-simulator.html` URL
- ran `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix broken PC simulator link in README by pointing to the current LVGL docs page, resolving the 404 in #167.

<sup>Written for commit 72783726ef825d7726c719de42eb38150db40217. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lvgl/lv_port_pc_eclipse/pull/168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

