### PR TITLE
docs: update LVGL PC simulator link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The [LVGL](https://github.com/lvgl/lvgl) is written mainly for microcontrollers and embedded systems however you can run the library **on your PC** as well without any embedded hardware. The code written on PC can be simply copied when your are using an embedded system.
 
-The PC simulator is cross platform.  **Windows, Linux and OSX** are supported, however on Windows it's easier to get started with a [another simulator](https://docs.lvgl.io/latest/en/html/get-started/pc-simulator.html) project.
+The PC simulator is cross platform.  **Windows, Linux and OSX** are supported, however on Windows it's easier to get started with a [another simulator](https://docs.lvgl.io/master/integration/pc/index.html) project.
 
 This project uses [Eclipse CDT](https://projects.eclipse.org/projects/tools.cdt) (as an IDE) and [SDL](https://www.libsdl.org/) =a low level driver library to open a window, and handle mouse, keyboard etc.)
 


### PR DESCRIPTION
Updates the README's LVGL PC simulator documentation link. The old `latest/en/html/get-started/pc-simulator.html` URL now redirects to a 404 page, while the current running-on-PC documentation page resolves successfully.

Validation:
- `curl.exe -L -I https://docs.lvgl.io/latest/en/html/get-started/pc-simulator.html` -> 404
- `curl.exe -L -I https://docs.lvgl.io/master/integration/pc/index.html` -> 200

Fixes #167.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the README to replace the broken LVGL PC simulator docs link with the current page at https://docs.lvgl.io/master/integration/pc/index.html. Fixes #167.

<sup>Written for commit 16d1cc49b084d272e2036af8fad3b7beeacfe4d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lvgl/lv_port_pc_eclipse/pull/169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

